### PR TITLE
Use publish action instead of preview

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: "Leanpub Publish Action"
-description: "A GitHub Action that publish your book LeanPub"
+description: "A GitHub Action that publishes your book LeanPub"
 author: "Robert Matusewicz <robert.matusewicz@protonmail.com>"
 inputs:
   api_key:

--- a/dist/index.js
+++ b/dist/index.js
@@ -19,10 +19,10 @@ const instance = axios.create(instanceConfig)
 
 const payload = `api_key=${api_key}`
 
-core.debug(`Leanpub preview URL base: ${instanceConfig.baseURL}`)
+core.debug(`Leanpub publish URL base: ${instanceConfig.baseURL}`)
 core.debug(`payload: ${payload}`)
 
-instance.post('/preview.json', payload)
+instance.post('/publish.json', payload)
 
 
 /***/ }),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "leanpub-preview-action",
+  "name": "leanpub-publish-action",
   "version": "1.0.0",
-  "description": "A Github Actions that triggers preview on LeanPub",
+  "description": "A GitHub Action that publishes your book LeanPub",
   "main": "index.js",
   "repository": "git@github.com:robert-matusewicz/leanpub-preview-action.git",
   "author": "Robert Matusewicz <robert.matusewicz@protonmail.com>",


### PR DESCRIPTION
Fixes call to the publish.json endpoint (the preview.json endpoint was
still being triggered from dist/index.js).